### PR TITLE
Clean up outdated example paths

### DIFF
--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -13,13 +13,13 @@ poetry install
 2. Generate sample configuration files (if you don't have them):
 
 ```bash
-poetry run data-extractor --generate-config examples/demo_config.yml --generate-tables examples/demo_tables.json
+poetry run data-extractor --generate-config config/config.yml --generate-tables config/tables.json
 ```
 
 3. Execute the demo script:
 
 ```bash
-poetry run python examples/demo.py --config examples/demo_config.yml --tables examples/demo_tables.json
+poetry run python examples/demo.py --config config/config.yml --tables config/tables.json
 ```
 
 The script loads the configuration, runs parallel extractions and prints a summary of successes and failures.

--- a/docs/development/CODE_CHANGE_CHECKLIST.md
+++ b/docs/development/CODE_CHANGE_CHECKLIST.md
@@ -5,4 +5,5 @@
 - [ ] Added documentation for Databricks usage
 - [ ] Created demo script
 - [ ] Implemented unit tests
+- [ ] Updated example paths in docs and scripts
 

--- a/examples/databricks_demo.py
+++ b/examples/databricks_demo.py
@@ -5,8 +5,8 @@ import os
 from data_extractor.databricks_job import run_from_widgets
 
 # Emulate widget values using environment variables
-os.environ["CONFIG_PATH"] = "examples/config.yml"
-os.environ["TABLES_PATH"] = "examples/tables.json"
+os.environ["CONFIG_PATH"] = "config/config.yml"
+os.environ["TABLES_PATH"] = "config/tables.json"
 
 if __name__ == "__main__":
     try:

--- a/examples/usage_examples.py
+++ b/examples/usage_examples.py
@@ -9,11 +9,14 @@ from data_extractor.config import ConfigManager
 from data_extractor.core import DataExtractor
 
 
-def example_config_file_usage():
+from typing import Dict
+
+
+def example_config_file_usage() -> Dict[str, bool]:
     """Demonstrate loading configs from files."""
-    config_manager = ConfigManager("examples/config.yml")
+    config_manager = ConfigManager("config/config.yml")
     db_config = config_manager.get_database_config()
-    table_configs = config_manager.load_table_configs_from_json("examples/tables.json")
+    table_configs = config_manager.load_table_configs_from_json("config/tables.json")
     extractor = DataExtractor(
         oracle_host=db_config["oracle_host"],
         oracle_port=db_config.get("oracle_port", "1521"),


### PR DESCRIPTION
## Summary
- fix config paths in example scripts
- update demo instructions
- extend code change checklist

## Testing
- `poetry run ruff check examples/databricks_demo.py examples/usage_examples.py`
- `poetry run mypy examples/databricks_demo.py examples/usage_examples.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f87e1f0b48326884dae32742319f4