### PR TITLE
Add configurable JDBC options

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -1,0 +1,6 @@
+# PR Checklist
+
+- [ ] Code compiles
+- [ ] Unit tests added and passing
+- [ ] Documentation updated
+- [ ] Example scripts updated

--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ Leverages Databricks-optimized Spark configuration:
 - Fetch size optimized for Oracle (10,000 rows)
 - Default 4 partitions per table for parallel reading (standard mode)
 - Dynamic partition count in Databricks based on cluster parallelism
+- **Configurable JDBC parameters**: `jdbc_fetch_size` and `jdbc_num_partitions`
+  can be tuned via the configuration file. See [docs/CONFIGURABLE_JDBC.md](docs/CONFIGURABLE_JDBC.md).
 - Connection pooling via Spark JDBC
 
 ### Databricks-Specific Optimizations

--- a/config/config.yml
+++ b/config/config.yml
@@ -13,6 +13,8 @@ extraction:
   max_workers: 8
   default_source: oracle_db
   run_id: null  # Auto-generated if null
+  jdbc_fetch_size: 10000
+  jdbc_num_partitions: 4
 
 # Databricks-specific configuration (optional)
 databricks:

--- a/data_extractor/config.py
+++ b/data_extractor/config.py
@@ -26,7 +26,11 @@ class AppSettings(BaseSettings):
     run_id: Optional[str] = Field(default=None, alias="RUN_ID")
     default_source: str = Field(default="default", alias="DEFAULT_SOURCE")
     use_existing_spark: Optional[bool] = Field(default=None, alias="USE_EXISTING_SPARK")
-    unity_catalog_volume: Optional[str] = Field(default=None, alias="UNITY_CATALOG_VOLUME")
+    unity_catalog_volume: Optional[str] = Field(
+        default=None, alias="UNITY_CATALOG_VOLUME"
+    )
+    jdbc_fetch_size: int = Field(default=10000, alias="JDBC_FETCH_SIZE")
+    jdbc_num_partitions: int = Field(default=4, alias="JDBC_NUM_PARTITIONS")
 
     model_config = SettingsConfigDict(env_file=None, extra="ignore")
 
@@ -97,6 +101,8 @@ class ConfigManager:
             "default_source",
             "use_existing_spark",
             "unity_catalog_volume",
+            "jdbc_fetch_size",
+            "jdbc_num_partitions",
         ]
         return {
             k: getattr(settings, k) for k in keys if getattr(settings, k) is not None
@@ -128,7 +134,12 @@ class ConfigManager:
                 "oracle_password": "your_password",
                 "output_base_path": "data",
             },
-            "extraction": {"max_workers": 8, "default_source": "oracle_db"},
+            "extraction": {
+                "max_workers": 8,
+                "default_source": "oracle_db",
+                "jdbc_fetch_size": 10000,
+                "jdbc_num_partitions": 4,
+            },
         }
         with open(config_path, "w", encoding="utf-8") as f:
             yaml.safe_dump(sample_config, f)

--- a/docs/CONFIGURABLE_JDBC.md
+++ b/docs/CONFIGURABLE_JDBC.md
@@ -1,0 +1,18 @@
+# Configurable JDBC Options
+
+The extractor now allows customization of JDBC fetch size and the number of partitions used for Spark reads.
+
+These settings help tune performance for different workloads and are controlled via the configuration file or environment variables:
+
+```yaml
+extraction:
+  jdbc_fetch_size: 10000
+  jdbc_num_partitions: 4
+```
+
+Environment variable overrides:
+
+- `JDBC_FETCH_SIZE`
+- `JDBC_NUM_PARTITIONS`
+
+Increasing these values can improve throughput when extracting large tables. Be sure to test different settings based on your cluster resources.

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -33,3 +33,11 @@ To try Oracle Flashback queries use:
 ```bash
 poetry run python examples/flashback_demo.py --config config/config.yml --tables config/tables.json --timestamp 2024-01-01T12:00:00
 ```
+
+### JDBC Options Demo
+
+You can check the configured JDBC fetch size and partition count with:
+
+```bash
+poetry run python examples/jdbc_config_demo.py
+```

--- a/examples/jdbc_config_demo.py
+++ b/examples/jdbc_config_demo.py
@@ -2,10 +2,16 @@
 
 from data_extractor.config import ConfigManager
 from data_extractor.core import DataExtractor
-
+from pathlib import Path
+import sys
 
 def main() -> None:
-    manager = ConfigManager("config/config.yml")
+    config_path = Path(__file__).parent / "config" / "config.yml"
+    if not config_path.is_file():
+        print(f"Error: Configuration file not found at {config_path}", file=sys.stderr)
+        sys.exit(1)
+
+    manager = ConfigManager(str(config_path))
     db_config = manager.get_database_config()
     extraction_config = manager.get_extraction_config()
 

--- a/examples/jdbc_config_demo.py
+++ b/examples/jdbc_config_demo.py
@@ -18,8 +18,8 @@ def main() -> None:
     extractor = DataExtractor(
         **db_config,
         max_workers=extraction_config.get("max_workers"),
-        jdbc_fetch_size=extraction_config.get("jdbc_fetch_size", 10000),
-        jdbc_num_partitions=extraction_config.get("jdbc_num_partitions", 4),
+        jdbc_fetch_size=extraction_config.get("jdbc_fetch_size", AppSettings.DEFAULT_FETCH_SIZE),
+        jdbc_num_partitions=extraction_config.get("jdbc_num_partitions", AppSettings.DEFAULT_NUM_PARTITIONS),
     )
 
     print(

--- a/examples/jdbc_config_demo.py
+++ b/examples/jdbc_config_demo.py
@@ -1,0 +1,25 @@
+"""Demonstration of configurable JDBC options."""
+
+from data_extractor.config import ConfigManager
+from data_extractor.core import DataExtractor
+
+
+def main() -> None:
+    manager = ConfigManager("config/config.yml")
+    db_config = manager.get_database_config()
+    extraction_config = manager.get_extraction_config()
+
+    extractor = DataExtractor(
+        **db_config,
+        max_workers=extraction_config.get("max_workers"),
+        jdbc_fetch_size=extraction_config.get("jdbc_fetch_size", 10000),
+        jdbc_num_partitions=extraction_config.get("jdbc_num_partitions", 4),
+    )
+
+    print(
+        f"Configured fetch size: {extractor.jdbc_fetch_size}, partitions: {extractor.jdbc_num_partitions}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_jdbc_options.py
+++ b/tests/test_jdbc_options.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import Mock, patch, call
+from data_extractor.config import ConfigManager
+from data_extractor.core import DataExtractor
+
+
+class TestJdbcOptions(unittest.TestCase):
+    def test_config_manager_returns_jdbc_options(self):
+        manager = ConfigManager("config/config.yml")
+        extraction = manager.get_extraction_config()
+        self.assertIn("jdbc_fetch_size", extraction)
+        self.assertIn("jdbc_num_partitions", extraction)
+
+    @patch("data_extractor.core.SparkSession")
+    def test_data_extractor_applies_jdbc_options(self, mock_session):
+        mock_builder = Mock()
+        mock_session.builder = mock_builder
+        mock_builder.appName.return_value = mock_builder
+        mock_builder.config.return_value = mock_builder
+        mock_builder.getOrCreate.return_value = Mock(read=Mock())
+
+        extractor = DataExtractor(
+            oracle_host="h",
+            oracle_port="1",
+            oracle_service="s",
+            oracle_user="u",
+            oracle_password="p",
+            jdbc_fetch_size=123,
+            jdbc_num_partitions=7,
+        )
+
+        with patch.object(extractor, "_get_spark_session") as get_spark:
+            spark = Mock()
+            reader = Mock()
+            reader.format.return_value = reader
+            reader.option.return_value = reader
+            reader.load.return_value = Mock(count=Mock(return_value=0))
+            spark.read = reader
+            get_spark.return_value = spark
+
+            result = extractor.extract_table(
+                source_name="src", table_name="tbl", is_full_extract=True
+            )
+
+        self.assertTrue(result)
+        self.assertIn(call("fetchsize", "123"), reader.option.call_args_list)
+        self.assertIn(call("numPartitions", "7"), reader.option.call_args_list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make JDBC fetch size and number of partitions configurable
- document JDBC tuning options
- demo configurable JDBC settings
- add unit tests for config-driven JDBC parameters

## Testing
- `poetry run pytest -q` *(fails: AttributeError: __enter__)*

------
https://chatgpt.com/codex/tasks/task_e_688007d1537c83269c861517268f4179