### PR TITLE
Add MinIO Spark docker env

### DIFF
--- a/CHECKLIST.md
+++ b/CHECKLIST.md
@@ -5,3 +5,4 @@
 - [ ] Documentation updated
 - [ ] Example scripts updated
 - [ ] SQL Server support added
+- [ ] Docker mock environment with MinIO and Spark

--- a/README.md
+++ b/README.md
@@ -63,6 +63,22 @@ poetry shell
 - Python 3.8+
 - Apache Spark 3.4+
 - Oracle JDBC Driver (automatically downloaded via Spark packages)
+
+## Docker Mock Environment
+
+The project includes a `docker-compose.yml` that spins up a complete test
+environment with Oracle XE, a Spark cluster and MinIO for S3-compatible storage.
+Use the provided `config/minio_config.yml` when running inside this setup.
+
+```bash
+docker-compose up --build
+docker-compose run --rm data-extractor \
+  python examples/minio_spark_demo.py \
+  --config config/minio_config.yml \
+  --tables config/tables.json
+```
+
+See [docs/MINIO_SPARK_DOCKER.md](docs/MINIO_SPARK_DOCKER.md) for details.
 - Oracle Database connectivity
 - Sufficient disk space for Parquet output files
 

--- a/config/minio_config.yml
+++ b/config/minio_config.yml
@@ -1,0 +1,22 @@
+# Data Extractor Configuration for MinIO Docker environment
+
+database:
+  oracle_host: oracle-db
+  oracle_port: 1521
+  oracle_service: XE
+  oracle_user: testuser
+  oracle_password: testpass
+  output_base_path: s3a://test-bucket/data
+
+extraction:
+  max_workers: 4
+  default_source: oracle_db
+  jdbc_fetch_size: 10000
+  jdbc_num_partitions: 4
+  spark_master: spark://spark-master:7077
+  s3_endpoint: http://minio:9000
+  s3_access_key: minioadmin
+  s3_secret_key: minioadmin
+
+databricks:
+  use_existing_spark: false

--- a/data_extractor/config.py
+++ b/data_extractor/config.py
@@ -38,6 +38,14 @@ class AppSettings(BaseSettings):
     jdbc_fetch_size: int = Field(default=10000, alias="JDBC_FETCH_SIZE")
     jdbc_num_partitions: int = Field(default=4, alias="JDBC_NUM_PARTITIONS")
 
+    # S3/MinIO configuration
+    s3_endpoint: Optional[str] = Field(default=None, alias="S3_ENDPOINT")
+    s3_access_key: Optional[str] = Field(default=None, alias="S3_ACCESS_KEY")
+    s3_secret_key: Optional[str] = Field(default=None, alias="S3_SECRET_KEY")
+
+    # Spark cluster configuration
+    spark_master: Optional[str] = Field(default=None, alias="SPARK_MASTER")
+
     model_config = SettingsConfigDict(env_file=None, extra="ignore")
 
 
@@ -122,6 +130,10 @@ class ConfigManager:
             "unity_catalog_volume",
             "jdbc_fetch_size",
             "jdbc_num_partitions",
+            "s3_endpoint",
+            "s3_access_key",
+            "s3_secret_key",
+            "spark_master",
         ]
         return {
             k: getattr(settings, k) for k in keys if getattr(settings, k) is not None
@@ -163,6 +175,10 @@ class ConfigManager:
                 "default_source": "oracle_db",
                 "jdbc_fetch_size": 10000,
                 "jdbc_num_partitions": 4,
+                "spark_master": "spark://spark-master:7077",
+                "s3_endpoint": "http://minio:9000",
+                "s3_access_key": "minioadmin",
+                "s3_secret_key": "minioadmin",
             },
         }
         with open(config_path, "w", encoding="utf-8") as f:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,10 @@ services:
       - SPARK_DRIVER_MEMORY=${SPARK_DRIVER_MEMORY:-2g}
       - SPARK_EXECUTOR_MEMORY=${SPARK_EXECUTOR_MEMORY:-2g}
       - PYSPARK_PYTHON=python3
+      - SPARK_MASTER=spark://spark-master:7077
+      - S3_ENDPOINT=http://minio:9000
+      - S3_ACCESS_KEY=minioadmin
+      - S3_SECRET_KEY=minioadmin
     
     # Volume mounts
     volumes:
@@ -59,6 +63,10 @@ services:
     
     depends_on:
       - oracle-db
+      - spark-master
+      - spark-worker
+      - minio
+      - minio-init
 
   # Mock Oracle Database for testing
   oracle-db:
@@ -81,6 +89,54 @@ services:
       timeout: 10s
       retries: 5
 
+  spark-master:
+    image: bitnami/spark:3.4
+    container_name: spark-master
+    environment:
+      - SPARK_MODE=master
+    ports:
+      - "7077:7077"
+      - "8080:8080"
+    networks:
+      - data-extractor-net
+
+  spark-worker:
+    image: bitnami/spark:3.4
+    container_name: spark-worker
+    environment:
+      - SPARK_MODE=worker
+      - SPARK_MASTER_URL=spark://spark-master:7077
+    depends_on:
+      - spark-master
+    ports:
+      - "8081:8081"
+    networks:
+      - data-extractor-net
+
+  minio:
+    image: minio/minio:latest
+    container_name: minio
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ACCESS_KEY=minioadmin
+      - MINIO_SECRET_KEY=minioadmin
+    volumes:
+      - minio-data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    networks:
+      - data-extractor-net
+
+  minio-init:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "until mc alias set myminio http://minio:9000 minioadmin minioadmin; do sleep 3; done; mc mb myminio/test-bucket;"
+    networks:
+      - data-extractor-net
+
 networks:
   data-extractor-net:
     driver: bridge
@@ -90,4 +146,6 @@ networks:
 
 volumes:
   oracle-data:
+    driver: local
+  minio-data:
     driver: local

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -34,6 +34,18 @@ To try Oracle Flashback queries use:
 poetry run python examples/flashback_demo.py --config config/config.yml --tables config/tables.json --timestamp 2024-01-01T12:00:00
 ```
 
+### MinIO/Spark Demo
+
+Run the Docker-based environment and execute the demo script that writes to
+MinIO:
+
+```bash
+docker-compose up -d
+poetry run python examples/minio_spark_demo.py \
+  --config config/minio_config.yml \
+  --tables config/tables.json
+```
+
 ### JDBC Options Demo
 
 You can check the configured JDBC fetch size and partition count with:

--- a/docs/MINIO_SPARK_DOCKER.md
+++ b/docs/MINIO_SPARK_DOCKER.md
@@ -1,0 +1,38 @@
+# Docker Mock Environment with MinIO and Spark
+
+This guide explains how to run the provided `docker-compose.yml` configuration to
+create a local environment containing:
+
+- Oracle XE with test data and Flashback enabled
+- A Spark master and worker
+- MinIO for S3-compatible storage
+- The data extractor container
+
+## Running the Environment
+
+```bash
+# Build images and start all services
+docker-compose up --build
+```
+
+The compose file initializes an Oracle database with sample tables and enables
+Flashback. A MinIO bucket named `test-bucket` is created automatically.
+Spark is started in standalone mode with one worker.
+
+## Writing to MinIO
+
+The configuration file `config/minio_config.yml` sets the output path to
+` s3a://test-bucket/data`. The data extractor container is already configured
+with the required S3 credentials and Spark master URL.
+
+To run an extraction inside the environment:
+
+```bash
+docker-compose run --rm data-extractor \
+  python examples/minio_spark_demo.py \
+  --config config/minio_config.yml \
+  --tables config/tables.json
+```
+
+Parquet files will be written to the MinIO bucket and can be inspected via the
+MinIO console at [http://localhost:9001](http://localhost:9001).

--- a/examples/minio_spark_demo.py
+++ b/examples/minio_spark_demo.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Demo extraction writing to MinIO using Spark cluster."""
+
+import argparse
+
+from data_extractor.config import ConfigManager
+from data_extractor.core import DataExtractor
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run MinIO demo extraction")
+    parser.add_argument(
+        "--config", default="config/minio_config.yml", help="Path to YAML config"
+    )
+    parser.add_argument(
+        "--tables", default="config/tables.json", help="Path to tables JSON"
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    cfg = ConfigManager(args.config)
+    params = cfg.get_runtime_config()
+
+    extractor = DataExtractor(
+        oracle_host=params["oracle_host"],
+        oracle_port=params.get("oracle_port", "1521"),
+        oracle_service=params["oracle_service"],
+        oracle_user=params["oracle_user"],
+        oracle_password=params["oracle_password"],
+        output_base_path=params.get("output_base_path", "data"),
+        max_workers=params.get("max_workers"),
+        jdbc_fetch_size=params.get("jdbc_fetch_size", 10000),
+        jdbc_num_partitions=params.get("jdbc_num_partitions", 4),
+        spark_master=params.get("spark_master"),
+        s3_endpoint=params.get("s3_endpoint"),
+        s3_access_key=params.get("s3_access_key"),
+        s3_secret_key=params.get("s3_secret_key"),
+    )
+
+    tables = cfg.load_table_configs_from_json(args.tables)
+    results = extractor.extract_tables_parallel(tables)
+    extractor.cleanup_spark_sessions()
+
+    success = sum(1 for ok in results.values() if ok)
+    total = len(results)
+    print(f"MinIO demo completed: {success}/{total} tables successful")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/init-oracle.sql
+++ b/scripts/init-oracle.sql
@@ -1,5 +1,15 @@
 -- Oracle test database initialization script
 
+-- Enable archive log and flashback
+CONNECT / AS SYSDBA;
+ALTER SYSTEM SET db_recovery_file_dest_size=2G;
+ALTER SYSTEM SET db_recovery_file_dest='/opt/oracle/oradata';
+SHUTDOWN IMMEDIATE;
+STARTUP MOUNT;
+ALTER DATABASE ARCHIVELOG;
+ALTER DATABASE FLASHBACK ON;
+ALTER DATABASE OPEN;
+
 -- Create test schema and tables
 CREATE USER testuser IDENTIFIED BY testpass;
 GRANT CREATE SESSION TO testuser;

--- a/tests/test_spark_minio.py
+++ b/tests/test_spark_minio.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import Mock, call, patch
+
+from data_extractor.core import DataExtractor
+
+
+class TestSparkAndS3Config(unittest.TestCase):
+    @patch("data_extractor.core.SparkSession")
+    def test_spark_master_and_s3_options(self, mock_session):
+        builder = Mock()
+        mock_session.builder = builder
+        builder.appName.return_value = builder
+        builder.config.return_value = builder
+        builder.master.return_value = builder
+        builder.getOrCreate.return_value = Mock()
+
+        extractor = DataExtractor(
+            oracle_host="h",
+            oracle_port="1",
+            oracle_service="s",
+            oracle_user="u",
+            oracle_password="p",
+            spark_master="spark://spark-master:7077",
+            s3_endpoint="http://minio:9000",
+            s3_access_key="key",
+            s3_secret_key="secret",
+        )
+
+        extractor._get_spark_session()
+
+        builder.master.assert_called_with("spark://spark-master:7077")
+        self.assertIn(
+            call("spark.hadoop.fs.s3a.endpoint", "http://minio:9000"),
+            builder.config.call_args_list,
+        )
+        self.assertIn(
+            call("spark.hadoop.fs.s3a.access.key", "key"), builder.config.call_args_list
+        )
+        self.assertIn(
+            call("spark.hadoop.fs.s3a.secret.key", "secret"),
+            builder.config.call_args_list,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add MinIO/Spark docker environment
- allow configuring Spark master and S3 options
- document how to use the new environment
- provide demo script and sample config
- enable flashback in Oracle init script
- add tests for new S3/Spark configuration

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d1357400832692c6e74ae4a65bf0